### PR TITLE
feat: add package installation step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+
     - name: Get version from __init__.py
       id: get_version
       run: |


### PR DESCRIPTION
This pull request adds an installation step to the release workflow to ensure the package is installed in the environment before proceeding with subsequent steps.

* Release workflow improvements:
  * [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R28-R32): Added a step to upgrade `pip` and install the package in editable mode using `pip install -e .`.## Description
<!-- Describe your changes in detail -->

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My commits follow the conventional commits specification

## Related Issues
<!-- Link any related issues here -->
Fixes #

## Additional Notes
<!-- Add any additional notes or context here -->
