### PR TITLE
fix: improve tag existence check in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,13 @@ jobs:
     - name: Check if tag exists
       id: check_tag
       run: |
-        if git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+        git fetch --tags
+        if git tag -l "v${{ steps.get_version.outputs.version }}" | grep -q .; then
           echo "exists=true" >> $GITHUB_OUTPUT
+          echo "Tag v${{ steps.get_version.outputs.version }} already exists, skipping release"
         else
           echo "exists=false" >> $GITHUB_OUTPUT
+          echo "Tag v${{ steps.get_version.outputs.version }} does not exist, will create release"
         fi
 
     - name: Generate changelog


### PR DESCRIPTION
This pull request updates the logic for checking if a git tag exists in the release workflow. The new approach ensures all tags are fetched before performing the check, which improves reliability for release automation.

* Release workflow improvements:
  * [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L43-R49): Added `git fetch --tags` before checking for existing tags to ensure the local repository is up-to-date, and replaced the previous check with a more robust tag listing and search. Also added clearer logging messages for tag existence.## Description
<!-- Describe your changes in detail -->

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] My commits follow the conventional commits specification

## Related Issues
<!-- Link any related issues here -->
Fixes #

## Additional Notes
<!-- Add any additional notes or context here -->
