### PR TITLE
fix: update tag pattern and release workflow for version handling

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -31,6 +31,6 @@ commit_parsers = [
   { body = ".*security", group = "Security" },
 ]
 filter_commits = false
-tag_pattern = "v[0-9].*"
+tag_pattern = "[0-9].*"
 topo_order = false
 sort_commits = "newest"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,10 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [published, created]
+  push:
+    tags:
+      - '[0-9]*'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,18 +35,18 @@ jobs:
       run: |
         VERSION=$(python -c "import aiorinnai; print(aiorinnai.__version__)")
         echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+        echo "tag=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Check if tag exists
       id: check_tag
       run: |
         git fetch --tags
-        if git tag -l "v${{ steps.get_version.outputs.version }}" | grep -q .; then
+        if git tag -l "${{ steps.get_version.outputs.version }}" | grep -q .; then
           echo "exists=true" >> $GITHUB_OUTPUT
-          echo "Tag v${{ steps.get_version.outputs.version }} already exists, skipping release"
+          echo "Tag ${{ steps.get_version.outputs.version }} already exists, skipping release"
         else
           echo "exists=false" >> $GITHUB_OUTPUT
-          echo "Tag v${{ steps.get_version.outputs.version }} does not exist, will create release"
+          echo "Tag ${{ steps.get_version.outputs.version }} does not exist, will create release"
         fi
 
     - name: Generate changelog


### PR DESCRIPTION
This pull request updates the release and publishing workflows to standardize version tag formats and improve automation triggers. The main changes involve removing the "v" prefix from version tags and expanding workflow triggers to ensure releases and package uploads are handled more consistently.

**Workflow and Tag Format Updates:**

* Updated the `tag_pattern` in `.github/cliff.toml` to match tags without the "v" prefix, simplifying version tag matching for changelog generation.
* Modified `.github/workflows/release.yml` to remove the "v" prefix from tag creation and existence checks, ensuring tags are now created and checked as plain version numbers.

**Workflow Trigger Improvements:**

* Expanded triggers in `.github/workflows/python-publish.yml` to run on both `published` and `created` release events, and to trigger on pushes to tags matching the new version pattern.## Description
<!-- Describe your changes in detail -->

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] My commits follow the conventional commits specification

## Related Issues
<!-- Link any related issues here -->
Fixes #

## Additional Notes
<!-- Add any additional notes or context here -->
