### PR TITLE
fix: update changelog generation args to include unreleased changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       uses: orhun/git-cliff-action@v4
       with:
         config: .github/cliff.toml
-        args: --verbose --latest --strip header
+        args: --verbose --unreleased --strip header
       env:
         OUTPUT: CHANGELOG.md
         GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
This pull request makes a small adjustment to the release workflow configuration, specifically to how changelogs are generated. The change updates the arguments passed to the `git-cliff-action` to generate the changelog for unreleased changes instead of just the latest release.

* Updated the `args` parameter in `.github/workflows/release.yml` to use `--unreleased` instead of `--latest`, ensuring the changelog includes all unreleased changes.## Description
<!-- Describe your changes in detail -->

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] My commits follow the conventional commits specification

## Related Issues
<!-- Link any related issues here -->
Fixes #

## Additional Notes
<!-- Add any additional notes or context here -->
