### PR TITLE
fix: refine release triggers and update publish step in workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,17 +5,21 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published, created]
+    types: [published]
   push:
     tags:
-      - '[0-9]*'
+      - '[0-9]*.[0-9]*.[0-9]*'
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aiorinnai
 
     steps:
     - uses: actions/checkout@v4
@@ -33,7 +37,5 @@ jobs:
     - name: Build package
       run: python -m build
 
-    - name: Publish package
+    - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This pull request updates the Python package publishing workflow for better security and more precise release triggering. The changes focus on restricting when the workflow runs, improving permissions, and clarifying deployment details.

**Workflow trigger and permissions updates:**

* The workflow now only triggers on published releases, not on created releases, and only for tags matching the full semantic version pattern (e.g., `1.2.3`), reducing accidental deployments.
* Added `id-token: write` permission to support OpenID Connect authentication, which is more secure than using a static API token.

**Deployment and job configuration:**

* The deployment job now specifies an environment named `pypi` with the PyPI package URL, improving traceability and environment management.
* The publish step is renamed to "Publish package to PyPI" for clarity, and the static password input is removed, likely relying on OpenID Connect for authentication.## Description
<!-- Describe your changes in detail -->

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] My commits follow the conventional commits specification

## Related Issues
<!-- Link any related issues here -->
Fixes #

## Additional Notes
<!-- Add any additional notes or context here -->
