### PR TITLE
feat: add package build step and update environment configuration for…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,14 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aiorinnai
 
     steps:
     - uses: actions/checkout@v4
@@ -89,3 +93,13 @@ jobs:
         generate_release_notes: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build package
+      if: steps.check_tag.outputs.exists == 'false'
+      run: |
+        python -m pip install build
+        python -m build
+
+    - name: Publish package to PyPI
+      if: steps.check_tag.outputs.exists == 'false'
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases, specifically enhancing the process for publishing Python packages to PyPI. The most important changes include improvements to permissions and environment configuration, and the addition of steps to build and publish the package.

**Workflow and Permissions Updates:**

* Added `id-token: write` permission to support secure authentication for publishing to PyPI.
* Configured the release job to use the `pypi` environment with the PyPI URL for deployment.

**Release Process Enhancements:**

* Added a step to build the Python package using `python -m build`, ensuring the package is prepared before publishing.
* Added a step to publish the built package to PyPI using the `pypa/gh-action-pypi-publish` action, streamlining the release workflow.… release workflow

## Description
<!-- Describe your changes in detail -->

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] My commits follow the conventional commits specification

## Related Issues
<!-- Link any related issues here -->
Fixes #

## Additional Notes
<!-- Add any additional notes or context here -->
